### PR TITLE
Add check for body type

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -10,6 +10,14 @@ var wrapError = function(model, options) {
         model.trigger('error', model, resp, options);
     };
 };
+var tryParseJSON = function(o){
+
+    // Check if the string is object
+    if (o && typeof o === 'object' && o !== null) {
+        return o;
+    }
+    return false;
+};
 
 module.exports = {
     // Fetch the default set of models for this collection, resetting the
@@ -21,6 +29,10 @@ module.exports = {
         var success = options.success;
         var collection = this;
         options.success = function(resp) {
+            if (!tryParseJSON(resp)){
+                options.error(resp);
+                return false;
+            }
             var method = options.reset ? 'reset' : 'set';
             collection[method](resp, options);
             if (success) success(collection, resp, options);


### PR DESCRIPTION
Following from: https://github.com/AmpersandJS/ampersand-model/issues/12 we were getting the same issue with collections since they were both using similar fetch() functions.

This checks if the returned body is a json object or not. On fetches it should return some data, or null. In the case of null fetch() should return some form of error. (internet disruptions, unauthorized access, etc).

Thoughts?

cc @funkytek
