### PR TITLE
use latest ampersand-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/ampersandjs/ampersand-collection-rest-mixin/issues"
   },
   "dependencies": {
-    "ampersand-sync": "^2.0.0",
+    "ampersand-sync": "^3.0.0",
     "ampersand-version": "^1.0.0",
     "extend-object": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-collection-rest-mixin",
   "description": "A mixin for extending ampersand-collection with restful methods.",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browserify": {
     "transform": [


### PR DESCRIPTION
beforeSend wasn't caught if the model/collection has `xhrFields`. This was fixed in `ampersand-sync@3.x.x`.

![ampersand-sync](https://cloud.githubusercontent.com/assets/113969/6512740/fbb8fc02-c32a-11e4-8f89-92744881cd61.png)

After this PR
- [ ] need to update `ampersand-model` to use new ampersand-sync as well
- [ ] need to update `ampersand-rest-collection`
