### PR TITLE
Return fetches, and add tests

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -54,6 +54,7 @@ module.exports = {
 
     // Get or fetch a model by Id.
     getOrFetch: function (id, options, cb) {
+
         if (arguments.length !== 3) {
             cb = options;
             options = {};
@@ -70,12 +71,12 @@ module.exports = {
             }
         }
         if (options.all) {
-            this.fetch({
+            return this.fetch({
                 success: done,
                 error: done
             });
         } else {
-            this.fetchById(id, cb);
+            return this.fetchById(id, cb);
         }
     },
 
@@ -86,7 +87,7 @@ module.exports = {
         var idObj = {};
         idObj[this.model.prototype.idAttribute] = id;
         var model = new this.model(idObj, {collection: this});
-        model.fetch({
+        return model.fetch({
             success: function () {
                 self.add(model);
                 if (cb) cb(null, model);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "ampersand-collection": "^1.3.15",
     "ampersand-model": "^4.0.2",
+    "bluebird": "^2.9.14",
     "browserify": "^5.11.1",
     "jshint": "^2.5.1",
     "phantomjs": "^1.9.7-15",

--- a/test/main.js
+++ b/test/main.js
@@ -3,6 +3,18 @@ var RestCollectionMixins = require('../ampersand-collection-rest-mixin');
 var AmpersandCollection = require('ampersand-collection');
 var AmpersandModel = require('ampersand-model');
 var Sync = require('ampersand-sync');
+
+// headless tape browser does not have Fn.prototype.bind. for real.
+var bind = function bind (fn, ctx){
+    var args = [].slice.call(arguments,2);
+
+    return function(){
+        return fn.apply(ctx, args);
+    };
+};
+
+var Promise = require('bluebird');
+
 var SuccessSync = function (method, model, options) {
     options.xhrImplementation = function (xhrOptions) {
         xhrOptions.success();
@@ -10,6 +22,19 @@ var SuccessSync = function (method, model, options) {
     };
     return Sync.call(this, method, model, options);
 };
+
+var PromiseSync = function (method, model, options) {
+    options.xhrImplementation = function (xhrOptions) {
+        xhrOptions.success();
+        return {};
+    };
+
+    var boundSync = bind(Sync, this, method, model, options);
+    // emulate syncs that implement a promise for fetch
+    return Promise.resolve(boundSync());
+};
+
+
 
 
 function endAfter (t, after) {
@@ -40,6 +65,8 @@ var Collection = AmpersandCollection.extend(RestCollectionMixins, {
         return RestCollectionMixins.sync.apply(this, arguments);
     }
 });
+
+
 
 
 test('Existence of methods', function (t) {
@@ -124,6 +151,32 @@ test('create', function (t) {
     t.equal(model.collection, collection);
 
     t.end();
+});
+
+test('doing something with the result of the fetch', function(t){
+    t.plan(1);
+
+    var SuccessModel = Model.extend({
+        url: 'http://foo.bar/item',
+        sync: PromiseSync
+    });
+
+    var SuccessCollection = Collection.extend({
+        url: 'http://foo.bar/items',
+        sync: PromiseSync,
+        model: SuccessModel
+    });
+
+    var fetchingStuff = [
+        new SuccessModel().fetch(),
+        new SuccessCollection().fetch(),
+        new SuccessCollection().fetchById(1), 
+        new SuccessCollection().getOrFetch(1)
+    ];
+    Promise.all(fetchingStuff).then(function(data){
+        t.equal(data.length, 4);
+        t.end();
+    });
 });
 
 test('create with validate:true enforces validation', function (t) {


### PR DESCRIPTION
At the moment, if your fetch returns something (like a promise) then the two methods `getOrFetch` and `fetchById` do not let you do anything with what is returned from the fetch method. 

I've added some return statements and tests to cover this.

