### PR TITLE
feature/add-noset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ A mixin for extending ampersand-collection with restful methods. To make it beha
 npm install ampersand-collection-rest-mixin
 ```
 
+## api
+- create(model, options)
+- fetch(options)
+    - `reset` [boolean] - executes a `reset` on the collection
+    - `noset` [boolean] - does *not update* collection from GET request.  uses the collection strictly as an api client.  the `success` handler is still triggered. useful in rare circumstances
+    - `success(collection, resp, options)` [function]
+    - `error(model, resp, options)` [function]
+- fetchById(id, cb) - fetches a model and adds it to collection when fetched
+- getOrFetch(id, options, cb) - get or fetch a model by id
+- [sync()](AmpersandJS/ampersand-sync)
+
 ## example
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -13,15 +13,32 @@ npm install ampersand-collection-rest-mixin
 ```
 
 ## api
-- create(model, options)
-- fetch(options)
-    - `reset` [boolean] - executes a `reset` on the collection
-    - `noset` [boolean] - does *not update* collection from GET request.  uses the collection strictly as an api client.  the `success` handler is still triggered. useful in rare circumstances
-    - `success(collection, resp, options)` [function]
-    - `error(model, resp, options)` [function]
-- fetchById(id, cb) - fetches a model and adds it to collection when fetched
-- getOrFetch(id, options, cb) - get or fetch a model by id
-- [sync()](AmpersandJS/ampersand-sync)
+
+##### create(model, options)
+Create a new instance of a model in this collection. Add the model to the collection immediately.
+
+###### options
+
+- `wait` - default: `false`. If set to true, we wait for the server to agree before updating the collection.
+
+##### fetch(options)
+Fetch the default set of models for this collection, and set them onto this collection.
+
+###### options
+
+- `reset` [boolean] - default: `false`.  Executes the `reset` method on the collection with server response instead of the set method.
+- `set` [boolean] - defaut: `true`.  When left true, executes the `reset` method on the collection with server response.  When set to false, the collection will *not be modified* after the HTTP request is complete.  This enables use of of the collection strictly as an API client.  The `success` and `error` handlers are still triggered. Useful in rare circumstances.
+- `success(collection, response, options)` [function] - default: `undefined`.  Called after the XHR has completed successfully and the collection is updated.
+- `error(model, response, options)` [function] - default: `undefined`.  Called after the XHR has failed.
+
+##### fetchById(id, cb)
+fetches a model and adds it to collection when fetched
+
+##### getOrFetch(id, options, cb)
+get or fetch a model by id
+
+##### sync()
+proxy to [ampersand-sync](AmpersandJS/ampersand-sync)
 
 ## example
 

--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -23,9 +23,9 @@ module.exports = {
         var collection = this;
         options.success = function(resp) {
             var method = options.reset ? 'reset' : 'set';
-            if (!options.noset) collection[method](resp, options);
+            if (options.set !== false) collection[method](resp, options);
             if (success) success(collection, resp, options);
-            if (!options.noset) collection.trigger('sync', collection, resp, options);
+            if (options.set !== false) collection.trigger('sync', collection, resp, options);
         };
         wrapError(this, options);
         return this.sync('read', this, options);

--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -23,9 +23,9 @@ module.exports = {
         var collection = this;
         options.success = function(resp) {
             var method = options.reset ? 'reset' : 'set';
-            collection[method](resp, options);
+            if (!options.noset) collection[method](resp, options);
             if (success) success(collection, resp, options);
-            collection.trigger('sync', collection, resp, options);
+            if (!options.noset) collection.trigger('sync', collection, resp, options);
         };
         wrapError(this, options);
         return this.sync('read', this, options);

--- a/test/main.js
+++ b/test/main.js
@@ -119,6 +119,29 @@ test('fetch with an error response triggers an error event', function (t) {
     collection.fetch();
 });
 
+test('noset - disable setting response onto collection', function(t){
+    t.plan(2);
+    var end = endAfter(t, 2);
+
+    var model = new Model({name: 'foo'});
+    var collection = new Collection();
+
+    var opts = {
+        noset: true,
+        success: function (collection, resp, options) {
+            t.equal(collection.models.length, 0, 'noset sets no models');
+            t.ok(resp);
+            end();
+        }
+    };
+    collection.sync = model.sync = function (method, collection, options) {
+        options.success(collection, [], options);
+    };
+
+    collection.fetch(opts);
+
+});
+
 test('ensure fetch only parses once', function (t) {
     t.plan(1);
 
@@ -171,7 +194,7 @@ test('doing something with the result of the fetch', function(t){
     var fetchingStuff = [
         new SuccessModel().fetch(),
         new SuccessCollection().fetch(),
-        new SuccessCollection().fetchById(1), 
+        new SuccessCollection().fetchById(1),
         new SuccessCollection().getOrFetch(1)
     ];
     Promise.all(fetchingStuff).then(function(data){
@@ -419,17 +442,17 @@ test('#15 getOrFetch call with parameters for ajax call', function (t) {
     var collection = new Collection();
     var param = {param: 'value'};
     collection.url = '/test';
-    
+
     collection.sync = function (param_method, param_collection, param_options) {
         t.equal(param_method, 'read');
         t.equal(param_collection, collection);
         t.equal(param_options.parse, true);
         t.equal(param_options.data, param);
-        
-        param_options.success(); 
+
+        param_options.success();
     };
-    
-    
+
+
     collection.getOrFetch(1, {all: true, data: param}, function (/*err, model*/) {
         t.end();
     });

--- a/test/main.js
+++ b/test/main.js
@@ -119,7 +119,7 @@ test('fetch with an error response triggers an error event', function (t) {
     collection.fetch();
 });
 
-test('noset - disable setting response onto collection', function(t){
+test('set: false - disable setting response onto collection', function(t){
     t.plan(2);
     var end = endAfter(t, 2);
 
@@ -127,8 +127,8 @@ test('noset - disable setting response onto collection', function(t){
     var collection = new Collection();
 
     var opts = {
-        noset: true,
-        success: function (collection, resp, options) {
+        set: false,
+        success: function (collection, resp) {
             t.equal(collection.models.length, 0, 'noset sets no models');
             t.ok(resp);
             end();

--- a/test/main.js
+++ b/test/main.js
@@ -129,7 +129,7 @@ test('set: false - disable setting response onto collection', function(t){
     var opts = {
         set: false,
         success: function (collection, resp) {
-            t.equal(collection.models.length, 0, 'noset sets no models');
+            t.equal(collection.models.length, 0, '`set: false` does not set models on collection');
             t.ok(resp);
             end();
         }


### PR DESCRIPTION
# problem statement
i have a collection defined that I intend on using *after* doing some processing in a webworker.  i want to be able to use `mycollection.fetch` as it has my API mapping already sorted out and ready to go.  i need raw data to pass to the webworker, otherwise passing in models/model-collections make webworkers explode for 'not being able to clone object's.  plus, it just doesn't make sense to `model/state`-ize the response until any `parse`-like mutations are done.

# solution
add config option in fetch to not update the collection!  in this regard, I can still get the collections data, just in raw form!