### PR TITLE
Return the correct error details when handling findById responses

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -91,9 +91,13 @@ module.exports = {
                 self.add(model);
                 if (cb) cb(null, model);
             },
-            error: function () {
+            error: function (collection, resp) {
                 delete model.collection;
-                if (cb) cb(Error('not found'));
+                if (cb) {
+                    var error = new Error(resp.statusText);
+                    error.status = resp.status;
+                    cb(error);
+                }
             }
         });
     }

--- a/test/main.js
+++ b/test/main.js
@@ -465,9 +465,9 @@ test("#28 When fetchByid's model.fetch() returns an error, pass the error detail
 
     var options = {
         error: function (collection, res) {
-            t.ok(res.hasOwnProperty('status'))
-            t.ok(res.hasOwnProperty('statusText'))
-            t.end()
+            t.equal(res.status, 400);
+            t.equal(res.statusText, 'Bad Request');
+            t.end();
         }
     }
 

--- a/test/main.js
+++ b/test/main.js
@@ -458,7 +458,7 @@ test('#15 getOrFetch call with parameters for ajax call', function (t) {
     });
 });
 
-test("#28 When fetchByid's model.fetch() returns an error, pass the error details to fetchById's caller", function (t) {
+test('#28 When fetchByid\'s model.fetch() returns an error, pass the error details to fetchById\'s caller', function (t) {
     t.plan(2);
 
     var collection = new Collection();
@@ -469,7 +469,7 @@ test("#28 When fetchByid's model.fetch() returns an error, pass the error detail
             t.equal(res.statusText, 'Bad Request');
             t.end();
         }
-    }
+    };
 
     collection.sync = function (method, model, options) {
         options.error({
@@ -478,4 +478,4 @@ test("#28 When fetchByid's model.fetch() returns an error, pass the error detail
         });
     };
     collection.fetch(options);
-})
+});

--- a/test/main.js
+++ b/test/main.js
@@ -457,3 +457,25 @@ test('#15 getOrFetch call with parameters for ajax call', function (t) {
         t.end();
     });
 });
+
+test("#28 When fetchByid's model.fetch() returns an error, pass the error details to fetchById's caller", function (t) {
+    t.plan(2);
+
+    var collection = new Collection();
+
+    var options = {
+        error: function (collection, res) {
+            t.ok(res.hasOwnProperty('status'))
+            t.ok(res.hasOwnProperty('statusText'))
+            t.end()
+        }
+    }
+
+    collection.sync = function (method, model, options) {
+        options.error({
+            status: 400,
+            statusText: 'Bad Request'
+        });
+    };
+    collection.fetch(options);
+})


### PR DESCRIPTION
According to the XHR docs[1], we can rely upon the presence of .status
and .statusText properties when handling XHR responses. As today's code
stands, if a findById request encounters an error, a blanket 'not found'
error is returned, ignoring the real HTTP status code and text. This
code makes status code and status text available to the findById callback.

[1] https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest