### PR TITLE
update to ampersand sync v4

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -28,7 +28,9 @@ module.exports = {
             if (options.set !== false) collection.trigger('sync', collection, resp, options);
         };
         wrapError(this, options);
-        return this.sync('read', this, options);
+        var request = this.sync('read', this, options);
+        options.xhr = request;
+        return request;
     },
 
     // Create a new instance of a model in this collection. Add the model to the

--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -29,6 +29,9 @@ module.exports = {
         };
         wrapError(this, options);
         var request = this.sync('read', this, options);
+        // Make the request available on the options object so it can be accessed
+        // further down the line by `parse`, sync listeners, etc
+        // https://github.com/AmpersandJS/ampersand-collection-rest-mixin/commit/d32d788aaff912387eb1106f2d7ad183ec39e11a#diff-84c84703169bf5017b1bc323653acaa3R32
         options.xhr = request;
         return request;
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/ampersandjs/ampersand-collection-rest-mixin/issues"
   },
   "dependencies": {
-    "ampersand-sync": "^3.0.3",
+    "ampersand-sync": "^4.0.0",
     "ampersand-version": "^1.0.0",
     "lodash.assign": "^3.0.0"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -386,7 +386,7 @@ test('#1939 - `parse` is passed `options`', function (t) {
             }
         },
         parse: function (data, options) {
-            t.equal(options.xhr.ajaxSettings.headers.someHeader, 'headerValue');
+            t.equal(options.xhr.headers.someheader, 'headerValue');
             t.end();
             return data;
         }


### PR DESCRIPTION
~~Do not merge yet~~

This PR is to show the failing test with ampersand-sync@4.0.0 and track upgrading to it.

I don't think this module needs any documentation updates about sync, so once we have a solution for https://github.com/AmpersandJS/ampersand-sync/issues/65 and tests pass I think this is safe to upgrade.

**Update**

Everything was available on the returned request so the mixin is no setting the xhr property on options to the returned request.

Closes #27 