### PR TITLE
Use mainIndex instead of idAttribute

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -91,7 +91,7 @@ module.exports = {
     fetchById: function (id, cb) {
         var self = this;
         var idObj = {};
-        idObj[this.model.prototype.idAttribute] = id;
+        idObj[this.mainIndex] = id;
         var model = new this.model(idObj, {collection: this});
         return model.fetch({
             success: function () {


### PR DESCRIPTION
- closes #14 

`collection.mainIndex` is already set for us, we should use that instead of `idAttribute`.
https://github.com/AmpersandJS/ampersand-collection/blob/master/ampersand-collection.js#L13-L16