### PR TITLE
Trigger the fetchById callback with the model that actually got added to the collection

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -95,7 +95,7 @@ module.exports = {
         var model = new this.model(idObj, {collection: this});
         return model.fetch({
             success: function () {
-                self.add(model);
+                model = self.add(model);
                 if (cb) cb(null, model);
             },
             error: function (collection, resp) {


### PR DESCRIPTION
So this is a fun one.

If you run
`collection.fetch()`
`collection.getOrFetch(id, function (err, model) {
})`

It's possible to end up with a model in the getOrFetch callback that is different to the canonical one in the collection. They will have the same id, and both have a reference to the collection, but they have different cids and are different models. That's because the `add` line will merge the two, but throw away the one from fetchById (called by getOrFetch).

This fix ensures we pass the correct model to the getOrFetch callback.

My brain doesn't work well enough to figure out how we would test this though.