### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,22 +15,21 @@
     "url": "https://github.com/ampersandjs/ampersand-collection-rest-mixin/issues"
   },
   "dependencies": {
-    "ampersand-sync": "^4.0.1",
+    "ampersand-sync": "^4.0.3",
     "ampersand-version": "^1.0.2",
     "lodash.assign": "^3.2.0"
   },
   "devDependencies": {
     "ampersand-collection": "^1.3.15",
-    "ampersand-model": "^5.0.3",
-    "bluebird": "^2.9.14",
-    "browserify": "^11.0.1",
+    "ampersand-model": "^6.0.2",
+    "bluebird": "^3.1.1",
+    "browserify": "^12.0.1",
     "jshint": "^2.5.1",
-    "phantomjs": "^1.9.7-15",
     "precommit-hook": "^3.0.0",
     "run-browser": "^2.0.2",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.0",
-    "tape-run": "^1.1.0"
+    "tape-run": "^2.1.0"
   },
   "homepage": "https://github.com/ampersandjs/ampersand-collection-rest-mixin",
   "keywords": [

--- a/test/main.js
+++ b/test/main.js
@@ -4,15 +4,6 @@ var AmpersandCollection = require('ampersand-collection');
 var AmpersandModel = require('ampersand-model');
 var Sync = require('ampersand-sync');
 
-// headless tape browser does not have Fn.prototype.bind. for real.
-var bind = function bind (fn, ctx){
-    var args = [].slice.call(arguments,2);
-
-    return function(){
-        return fn.apply(ctx, args);
-    };
-};
-
 /* global -Promise */
 var Promise = require('bluebird');
 
@@ -30,7 +21,7 @@ var PromiseSync = function (method, model, options) {
         return {};
     };
 
-    var boundSync = bind(Sync, this, method, model, options);
+    var boundSync = Sync.bind(this, method, model, options);
     // emulate syncs that implement a promise for fetch
     return Promise.resolve(boundSync());
 };


### PR DESCRIPTION
Now that tape-run is installed (which uses Electron by default), the bind polyfull is no longer needed for tests. As well, phantomjs is no longer needed to be installed.