### PR TITLE
Fix missing statusText and status code

### DIFF
--- a/ampersand-collection-rest-mixin.js
+++ b/ampersand-collection-rest-mixin.js
@@ -93,19 +93,23 @@ module.exports = {
         var idObj = {};
         idObj[this.mainIndex] = id;
         var model = new this.model(idObj, {collection: this});
-        return model.fetch({
+        
+        var xhr = model.fetch({
             success: function () {
                 model = self.add(model);
                 if (cb) cb(null, model);
             },
-            error: function (collection, resp) {
+            error: function () {
                 delete model.collection;
+                
                 if (cb) {
-                    var error = new Error(resp.statusText);
-                    error.status = resp.status;
+                    var error = new Error(xhr.statusText);
+                    error.status = xhr.status;
                     cb(error);
                 }
             }
         });
+        
+        return xhr;
     }
 };


### PR DESCRIPTION
Before, `resp` didn't have `statusText` and `status` as properties. Instead, those properties were accessible through either `resp.rawRequest` or through the value returned from calling `model.fetch` (both, I believe are the xhr instance)

Related to #31

(this might be worth waiting for #38 to be accepted, so I could merge that into this branch, to avoid conflicts)